### PR TITLE
chore(deps): update default registry's baseline to `0ca64b4e1c70fa6d9f53b369b8f3f0843797c20c`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "4b3b6201414638abfcd8ef4629dfbd958985667e"
+    "baseline": "0ca64b4e1c70fa6d9f53b369b8f3f0843797c20c"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `0ca64b4e1c70fa6d9f53b369b8f3f0843797c20c`.