### PR TITLE
chore(deps): update default registry's baseline to `bea476a80218a581bcb5318595849520217c825e`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "0ca64b4e1c70fa6d9f53b369b8f3f0843797c20c"
+    "baseline": "bea476a80218a581bcb5318595849520217c825e"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `bea476a80218a581bcb5318595849520217c825e`.