### PR TITLE
chore(deps): update default registry's baseline to `3de032f834a9b28a455e35600b03e9d365ce3b85`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "bea476a80218a581bcb5318595849520217c825e"
+    "baseline": "3de032f834a9b28a455e35600b03e9d365ce3b85"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `3de032f834a9b28a455e35600b03e9d365ce3b85`.