### PR TITLE
chore(deps): update default registry's baseline to `56bb2411609227288b70117ead2c47585ba07713`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "62159a45e18f3a9ac0548628dcaf74fcb60c6ff9"
+    "baseline": "56bb2411609227288b70117ead2c47585ba07713"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `56bb2411609227288b70117ead2c47585ba07713`.